### PR TITLE
Make EMP Grenades Hurt

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -720,6 +720,7 @@
       "emp_blast_radius": 4,
       "sound_volume": 0,
       "sound_msg": "Tick.",
+      "explosion": { "power": 240, "shrapnel": { "casing_mass": 1285, "fragment_mass": 0.2 } },
       "no_deactivate_msg": "You've already pulled the %s's pin, try throwing it instead."
     },
     "flags": [ "TRADER_AVOID" ]


### PR DESCRIPTION
#### Summary


SUMMARY: Balance "Gives EMP Grenade explosion 40% of the EMP Bomb's power"

#### Purpose of change
This change fixes the fact that holding an EMP Bomb in your hand until detonation is harmless.
#### Describe the solution
I gave the EMP Grenade 40% of the EMP Bomb's explosion damage since the radius of the EMP Grenade is 60% smaller than the Bomb version's.

#### Describe alternatives you've considered
None
#### Testing
I edited the grenade's json file and tested it in a copy of CDDA I use for testing and spawned the emp grenade in. I then detonated it in my hand and died.

#### Additional context
None.
